### PR TITLE
Replace orm from beego to bun

### DIFF
--- a/BEEGO_TO_BUN_MIGRATION.md
+++ b/BEEGO_TO_BUN_MIGRATION.md
@@ -1,0 +1,166 @@
+# Harbor ORM Migration: Beego to Bun
+
+## 概述
+
+本文档详细说明了将 Harbor 项目从 Beego ORM v2 迁移到 Bun ORM 的完整计划和实施步骤。
+
+## 迁移范围
+
+### 当前 Beego ORM 使用情况
+- **依赖包**: `github.com/beego/beego/v2 v2.3.6`
+- **主要包**: 
+  - `github.com/beego/beego/v2/client/orm` - ORM 核心
+  - `github.com/beego/beego/v2/server/web` - Web 框架
+- **影响文件**: 50+ 个模型文件，100+ 个 DAO 文件
+- **数据库**: PostgreSQL (主要)
+
+### 目标 Bun ORM
+- **包**: `github.com/uptrace/bun`
+- **数据库驱动**: `github.com/uptrace/bun/driver/pgdriver`
+- **额外包**: `github.com/uptrace/bun/dialect/pgdialect`
+
+## 迁移计划
+
+### Phase 1: 依赖和初始化迁移
+
+#### 1.1 更新 go.mod
+```diff
+- github.com/beego/beego/v2 v2.3.6
++ github.com/uptrace/bun v1.1.16
++ github.com/uptrace/bun/driver/pgdriver v1.1.16
++ github.com/uptrace/bun/dialect/pgdialect v1.1.16
++ github.com/uptrace/bun/extra/bundebug v1.1.16
+```
+
+#### 1.2 数据库连接初始化
+- 替换 `orm.RegisterDataBase()` 为 Bun 连接
+- 更新连接池配置
+- 迁移事务管理
+
+### Phase 2: 模型定义迁移
+
+#### 2.1 结构体标签迁移
+**Beego 标签 → Bun 标签映射:**
+
+| Beego 标签 | Bun 标签 | 说明 |
+|------------|----------|------|
+| `orm:"pk;auto;column(id)"` | `bun:",pk,autoincrement"` | 主键自增 |
+| `orm:"column(name)"` | `bun:"name"` | 列名 |
+| `orm:"auto_now_add"` | `bun:",nullzero,notnull,default:current_timestamp"` | 创建时间 |
+| `orm:"auto_now"` | `bun:",nullzero,notnull,default:current_timestamp"` | 更新时间 |
+| `orm:"-"` | `bun:"-"` | 忽略字段 |
+| `orm:"size(255)"` | `bun:",type:varchar(255)"` | 字段类型 |
+
+#### 2.2 模型注册迁移
+- 移除 `orm.RegisterModel()` 调用
+- 使用 Bun 的表创建机制
+
+### Phase 3: ORM 操作迁移
+
+#### 3.1 查询操作
+**Beego → Bun:**
+```go
+// Before (Beego)
+o := orm.NewOrm()
+var projects []Project
+_, err := o.QueryTable("project").Filter("deleted", false).All(&projects)
+
+// After (Bun)
+err := db.NewSelect().Model(&projects).Where("deleted = ?", false).Scan(ctx)
+```
+
+#### 3.2 插入操作
+```go
+// Before (Beego)
+id, err := o.Insert(&project)
+
+// After (Bun)
+_, err := db.NewInsert().Model(&project).Exec(ctx)
+```
+
+#### 3.3 更新操作
+```go
+// Before (Beego)
+_, err := o.Update(&project)
+
+// After (Bun)
+_, err := db.NewUpdate().Model(&project).WherePK().Exec(ctx)
+```
+
+### Phase 4: 中间件和上下文迁移
+
+#### 4.1 ORM 中间件重构
+- 更新 `src/server/middleware/orm/orm.go`
+- 重构上下文传递机制
+- 更新 `src/lib/orm/orm.go`
+
+#### 4.2 事务处理迁移
+- 重构 `WithTransaction` 函数
+- 更新事务上下文管理
+
+### Phase 5: 测试迁移
+
+#### 5.1 Mock 对象更新
+- 重构 `FakeOrmer` 类型
+- 更新测试用例中的 ORM 调用
+- 重构数据库测试工具
+
+## 实施步骤
+
+### 步骤 1: 核心依赖迁移
+1. 更新 `go.mod` 文件
+2. 创建新的数据库连接管理器
+3. 保持兼容性的适配层
+
+### 步骤 2: 模型逐步迁移
+1. 从最小的模型开始 (如 `ConfigEntry`)
+2. 逐个更新模型定义
+3. 验证数据库操作
+
+### 步骤 3: DAO 层迁移
+1. 更新每个包的 DAO 实现
+2. 保持接口不变，只修改内部实现
+3. 逐步测试验证
+
+### 步骤 4: 中间件层迁移
+1. 重构 ORM 中间件
+2. 更新上下文处理
+3. 验证整体流程
+
+### 步骤 5: 测试和验证
+1. 运行完整测试套件
+2. 性能基准测试
+3. 集成测试验证
+
+## 注意事项
+
+### 兼容性考虑
+- Bun 使用不同的查询构建语法
+- 需要重写复杂查询
+- 事务处理模型不同
+
+### 性能优化
+- Bun 提供更好的查询性能
+- 支持查询缓存
+- 更好的连接池管理
+
+### 风险缓解
+- 创建完整的备份
+- 分阶段实施，保持可回滚性
+- 完整的测试覆盖
+
+## 预期收益
+
+1. **性能提升**: Bun 提供更好的查询性能和内存使用
+2. **现代化**: 支持 Go 泛型，类型安全的查询
+3. **开发体验**: 更直观的 API 和更好的调试支持
+4. **维护性**: 更清晰的代码结构和更好的错误处理
+
+## 时间线
+
+- **准备阶段**: 1-2 天
+- **核心迁移**: 5-7 天
+- **测试验证**: 2-3 天
+- **文档更新**: 1 天
+
+**总计**: 约 2 周时间

--- a/IMPLEMENTATION_GUIDE.md
+++ b/IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,435 @@
+# Harbor Beego 到 Bun ORM 迁移实施指南
+
+## 开始之前
+
+### 1. 安装依赖
+
+首先确保新的 Bun 依赖已添加到 `go.mod`：
+
+```bash
+cd src
+go mod tidy
+```
+
+### 2. 使用自动化迁移工具
+
+使用我们创建的迁移工具来转换现有模型：
+
+```bash
+# 转换单个模型文件
+go run tools/migration/beego_to_bun.go src/pkg/project/models/project.go
+
+# 批量转换多个文件
+find src -name "*.go" -path "*/models/*" -exec grep -l "orm:\"" {} \; | while read file; do
+    echo "Converting $file"
+    go run tools/migration/beego_to_bun.go "$file"
+done
+```
+
+## 分阶段迁移策略
+
+### 第一阶段：核心基础设施
+
+#### 1. 初始化 Bun 数据库连接
+
+在 `src/core/main.go` 中添加 Bun 初始化：
+
+```go
+import (
+    "github.com/goharbor/harbor/src/lib/bunorm"
+)
+
+func initBunDB() {
+    config := &bunorm.Config{
+        Host:         os.Getenv("POSTGRESQL_HOST"),
+        Port:         5432,
+        Username:     os.Getenv("POSTGRESQL_USERNAME"),
+        Password:     os.Getenv("POSTGRESQL_PASSWORD"),
+        Database:     os.Getenv("POSTGRESQL_DATABASE"),
+        SSLMode:      os.Getenv("POSTGRESQL_SSLMODE"),
+        MaxIdleConns: 50,
+        MaxOpenConns: 100,
+        MaxLifetime:  time.Hour,
+        ConnTimeout:  time.Second * 30,
+    }
+    
+    if err := bunorm.InitDB(config); err != nil {
+        log.Fatalf("Failed to initialize Bun database: %v", err)
+    }
+}
+
+func main() {
+    // ... existing code ...
+    
+    // Initialize Bun DB alongside existing Beego ORM
+    initBunDB()
+    
+    // ... rest of main function ...
+}
+```
+
+#### 2. 更新中间件链
+
+在路由设置中添加 Bun 中间件：
+
+```go
+import (
+    "github.com/goharbor/harbor/src/server/middleware/bunorm"
+)
+
+// 在需要数据库访问的路由上添加 Bun 中间件
+router.Use(bunorm.Middleware())
+```
+
+### 第二阶段：模型迁移
+
+#### 1. 创建 Bun 版本的核心模型
+
+优先迁移以下核心模型：
+- `ConfigEntry` (已完成)
+- `Project` (已完成) 
+- `User`
+- `Repository`
+- `Artifact`
+
+#### 2. 示例：User 模型迁移
+
+```go
+// Bun 版本的 User 模型
+type BunUser struct {
+    bun.BaseModel `bun:"table:harbor_user"`
+
+    UserID       int64     `bun:",pk,autoincrement" json:"user_id"`
+    Username     string    `bun:"username,unique,notnull" json:"username"`
+    Email        string    `bun:"email,unique,notnull" json:"email"`
+    Password     string    `bun:"password,notnull" json:"-"`
+    Realname     string    `bun:"realname" json:"realname"`
+    Comment      string    `bun:"comment" json:"comment"`
+    Deleted      bool      `bun:"deleted,notnull,default:false" json:"deleted"`
+    ResetUUID    string    `bun:"reset_uuid" json:"reset_uuid"`
+    Salt         string    `bun:"salt" json:"-"`
+    SysAdminFlag bool      `bun:"sysadmin_flag,notnull,default:false" json:"sysadmin_flag"`
+    CreationTime time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"creation_time"`
+    UpdateTime   time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"update_time"`
+}
+```
+
+### 第三阶段：DAO 层迁移
+
+#### 1. 创建 Bun 版本的 DAO 接口
+
+```go
+// DAO 接口保持不变，内部实现切换到 Bun
+type ProjectDAO interface {
+    Create(ctx context.Context, project *models.Project) (int64, error)
+    Get(ctx context.Context, id int64) (*models.Project, error)
+    List(ctx context.Context, query *models.ProjectQuery) ([]*models.Project, error)
+    Update(ctx context.Context, project *models.Project) error
+    Delete(ctx context.Context, id int64) error
+}
+
+// Bun 实现
+type bunProjectDAO struct{}
+
+func (d *bunProjectDAO) Create(ctx context.Context, project *models.Project) (int64, error) {
+    db, err := bunorm.FromContext(ctx)
+    if err != nil {
+        return 0, err
+    }
+    
+    bunProject := convertToBunProject(project)
+    _, err = db.NewInsert().Model(bunProject).Exec(ctx)
+    if err != nil {
+        return 0, err
+    }
+    
+    return bunProject.ProjectID, nil
+}
+
+func (d *bunProjectDAO) Get(ctx context.Context, id int64) (*models.Project, error) {
+    db, err := bunorm.FromContext(ctx)
+    if err != nil {
+        return nil, err
+    }
+    
+    var bunProject models.BunProject
+    err = db.NewSelect().Model(&bunProject).Where("project_id = ?", id).Scan(ctx)
+    if err != nil {
+        return nil, err
+    }
+    
+    return convertFromBunProject(&bunProject), nil
+}
+```
+
+#### 2. 模型转换函数
+
+创建 Beego 和 Bun 模型之间的转换函数：
+
+```go
+func convertToBunProject(project *models.Project) *models.BunProject {
+    return &models.BunProject{
+        ProjectID:    project.ProjectID,
+        OwnerID:      project.OwnerID,
+        Name:         project.Name,
+        CreationTime: project.CreationTime,
+        UpdateTime:   project.UpdateTime,
+        Deleted:      project.Deleted,
+        RegistryID:   project.RegistryID,
+        // 复制其他字段...
+    }
+}
+
+func convertFromBunProject(bunProject *models.BunProject) *models.Project {
+    return &models.Project{
+        ProjectID:    bunProject.ProjectID,
+        OwnerID:      bunProject.OwnerID,
+        Name:         bunProject.Name,
+        CreationTime: bunProject.CreationTime,
+        UpdateTime:   bunProject.UpdateTime,
+        Deleted:      bunProject.Deleted,
+        RegistryID:   bunProject.RegistryID,
+        // 复制其他字段...
+    }
+}
+```
+
+### 第四阶段：渐进式切换
+
+#### 1. 功能标志切换
+
+使用环境变量控制是否使用 Bun：
+
+```go
+func getProjectDAO(ctx context.Context) ProjectDAO {
+    if os.Getenv("USE_BUN_ORM") == "true" {
+        return &bunProjectDAO{}
+    }
+    return &beegoProjectDAO{} // 现有的 Beego 实现
+}
+```
+
+#### 2. 双写验证
+
+在关键操作中同时写入两个 ORM，用于验证数据一致性：
+
+```go
+func (d *dualProjectDAO) Create(ctx context.Context, project *models.Project) (int64, error) {
+    // 主要写入 Beego
+    id, err := d.beegoDAO.Create(ctx, project)
+    if err != nil {
+        return 0, err
+    }
+    
+    // 验证写入 Bun（异步）
+    go func() {
+        bunID, bunErr := d.bunDAO.Create(ctx, project)
+        if bunErr != nil || bunID != id {
+            log.Errorf("Bun write verification failed: id=%d, bunID=%d, err=%v", id, bunID, bunErr)
+        }
+    }()
+    
+    return id, nil
+}
+```
+
+## 测试策略
+
+### 1. 单元测试
+
+```go
+func TestBunProjectDAO_Create(t *testing.T) {
+    // 设置测试数据库
+    config := &bunorm.Config{
+        Host:     "localhost",
+        Port:     5432,
+        Username: "test",
+        Password: "test",
+        Database: "test_harbor",
+        SSLMode:  "disable",
+    }
+    
+    err := bunorm.InitDB(config)
+    require.NoError(t, err)
+    
+    // 清理测试数据
+    defer func() {
+        db := bunorm.GetDB()
+        _, err := db.NewDelete().Model((*models.BunProject)(nil)).Where("name LIKE 'test_%'").Exec(context.Background())
+        require.NoError(t, err)
+    }()
+    
+    dao := &bunProjectDAO{}
+    project := &models.Project{
+        Name:    "test_project",
+        OwnerID: 1,
+    }
+    
+    id, err := dao.Create(context.Background(), project)
+    require.NoError(t, err)
+    require.Greater(t, id, int64(0))
+    
+    // 验证创建的项目
+    retrieved, err := dao.Get(context.Background(), id)
+    require.NoError(t, err)
+    assert.Equal(t, project.Name, retrieved.Name)
+    assert.Equal(t, project.OwnerID, retrieved.OwnerID)
+}
+```
+
+### 2. 集成测试
+
+```go
+func TestProjectWorkflow_WithBun(t *testing.T) {
+    // 使用真实的 HTTP 请求测试完整工作流
+    os.Setenv("USE_BUN_ORM", "true")
+    defer os.Unsetenv("USE_BUN_ORM")
+    
+    // 创建项目
+    resp := testCreateProject(t, "test_project")
+    projectID := extractProjectID(resp)
+    
+    // 获取项目
+    project := testGetProject(t, projectID)
+    assert.Equal(t, "test_project", project.Name)
+    
+    // 更新项目
+    project.Name = "updated_project"
+    testUpdateProject(t, project)
+    
+    // 删除项目
+    testDeleteProject(t, projectID)
+}
+```
+
+### 3. 性能基准测试
+
+```go
+func BenchmarkProjectDAO_List(b *testing.B) {
+    setupBenchmarkData(b)
+    
+    b.Run("Beego", func(b *testing.B) {
+        dao := &beegoProjectDAO{}
+        for i := 0; i < b.N; i++ {
+            _, err := dao.List(context.Background(), &models.ProjectQuery{})
+            if err != nil {
+                b.Fatal(err)
+            }
+        }
+    })
+    
+    b.Run("Bun", func(b *testing.B) {
+        dao := &bunProjectDAO{}
+        for i := 0; i < b.N; i++ {
+            _, err := dao.List(context.Background(), &models.ProjectQuery{})
+            if err != nil {
+                b.Fatal(err)
+            }
+        }
+    })
+}
+```
+
+## 数据迁移脚本
+
+### 1. 验证数据一致性
+
+```sql
+-- 验证项目表数据一致性
+SELECT 
+    COUNT(*) as total_projects,
+    COUNT(CASE WHEN deleted = true THEN 1 END) as deleted_projects,
+    MIN(creation_time) as earliest_project,
+    MAX(creation_time) as latest_project
+FROM project;
+```
+
+### 2. 性能优化建议
+
+```sql
+-- 为 Bun 查询添加必要的索引
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_project_owner_id ON project(owner_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_project_name ON project(name);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_project_registry_id ON project(registry_id);
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_project_deleted ON project(deleted);
+```
+
+## 回滚计划
+
+### 1. 快速回滚
+
+```go
+// 通过环境变量快速切回 Beego
+os.Setenv("USE_BUN_ORM", "false")
+```
+
+### 2. 数据恢复
+
+```bash
+# 如果数据出现问题，从备份恢复
+pg_restore -h localhost -U harbor -d harbor_db /backup/harbor_backup.sql
+```
+
+## 监控和告警
+
+### 1. 性能监控
+
+```go
+// 添加 Bun 查询的性能监控
+func (d *bunProjectDAO) List(ctx context.Context, query *models.ProjectQuery) ([]*models.Project, error) {
+    start := time.Now()
+    defer func() {
+        duration := time.Since(start)
+        metrics.DBQueryDuration.WithLabelValues("bun", "project", "list").Observe(duration.Seconds())
+    }()
+    
+    // ... 实际查询逻辑
+}
+```
+
+### 2. 错误监控
+
+```go
+// 监控 Bun 查询错误
+if err != nil {
+    metrics.DBQueryErrors.WithLabelValues("bun", "project", "list").Inc()
+    log.Errorf("Bun query failed: %v", err)
+    return nil, err
+}
+```
+
+## 最终切换检查清单
+
+- [ ] 所有核心模型已迁移到 Bun
+- [ ] 所有 DAO 实现已更新
+- [ ] 单元测试全部通过
+- [ ] 集成测试全部通过
+- [ ] 性能基准测试满足要求
+- [ ] 生产环境双写验证通过
+- [ ] 监控和告警配置完成
+- [ ] 回滚计划已验证
+- [ ] 团队培训已完成
+- [ ] 文档已更新
+
+## 预期收益验证
+
+### 1. 性能提升测试
+
+```bash
+# 运行性能基准测试
+go test -bench=. ./src/pkg/project/dao/...
+
+# 监控生产环境性能指标
+# - 查询响应时间
+# - 数据库连接池使用率
+# - 内存使用情况
+```
+
+### 2. 开发体验改善
+
+- 类型安全的查询构建
+- 更好的错误处理
+- 更直观的 API
+- 支持 Go 泛型
+
+这个迁移将显著提升 Harbor 项目的性能和开发体验，同时保持向后兼容性和数据完整性。

--- a/src/examples/bun_migration_test.go
+++ b/src/examples/bun_migration_test.go
@@ -1,0 +1,435 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package examples
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/goharbor/harbor/src/lib/bunorm"
+	"github.com/goharbor/harbor/src/lib/config/models"
+	projectModels "github.com/goharbor/harbor/src/pkg/project/models"
+)
+
+// TestBunMigration demonstrates the migration from Beego to Bun ORM
+func TestBunMigration(t *testing.T) {
+	// Skip if no test database configured
+	if os.Getenv("TEST_DB_HOST") == "" {
+		t.Skip("No test database configured")
+	}
+
+	// Initialize Bun database
+	config := &bunorm.Config{
+		Host:         os.Getenv("TEST_DB_HOST"),
+		Port:         5432,
+		Username:     os.Getenv("TEST_DB_USER"),
+		Password:     os.Getenv("TEST_DB_PASSWORD"),
+		Database:     os.Getenv("TEST_DB_NAME"),
+		SSLMode:      "disable",
+		MaxIdleConns: 10,
+		MaxOpenConns: 20,
+		MaxLifetime:  time.Hour,
+		ConnTimeout:  time.Second * 30,
+	}
+
+	err := bunorm.InitDB(config)
+	require.NoError(t, err)
+	defer bunorm.Close()
+
+	t.Run("ConfigEntry Migration", testConfigEntryMigration)
+	t.Run("Project Migration", testProjectMigration)
+	t.Run("Transaction Example", testTransactionExample)
+	t.Run("Query Builder Example", testQueryBuilderExample)
+}
+
+// testConfigEntryMigration demonstrates ConfigEntry model migration
+func testConfigEntryMigration(t *testing.T) {
+	ctx := context.Background()
+	db := bunorm.NewDB()
+
+	// Clean up test data
+	defer func() {
+		_, err := db.NewDelete().
+			Model((*models.BunConfigEntry)(nil)).
+			Where("k LIKE 'test_%'").
+			Exec(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Create a new config entry using Bun
+	configEntry := &models.BunConfigEntry{
+		Key:   "test_config_key",
+		Value: "test_config_value",
+	}
+
+	// Insert using Bun ORM
+	_, err := db.NewInsert().Model(configEntry).Exec(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, configEntry.ID, int64(0))
+
+	// Read back the config entry
+	var retrieved models.BunConfigEntry
+	err = db.NewSelect().
+		Model(&retrieved).
+		Where("id = ?", configEntry.ID).
+		Scan(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, configEntry.Key, retrieved.Key)
+	assert.Equal(t, configEntry.Value, retrieved.Value)
+
+	// Update the config entry
+	retrieved.Value = "updated_value"
+	_, err = db.NewUpdate().
+		Model(&retrieved).
+		WherePK().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// Verify update
+	var updated models.BunConfigEntry
+	err = db.NewSelect().
+		Model(&updated).
+		Where("id = ?", configEntry.ID).
+		Scan(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "updated_value", updated.Value)
+
+	// Delete the config entry
+	_, err = db.NewDelete().
+		Model(&retrieved).
+		WherePK().
+		Exec(ctx)
+	require.NoError(t, err)
+
+	// Verify deletion
+	var count int
+	count, err = db.NewSelect().
+		Model((*models.BunConfigEntry)(nil)).
+		Where("id = ?", configEntry.ID).
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+// testProjectMigration demonstrates Project model migration
+func testProjectMigration(t *testing.T) {
+	ctx := context.Background()
+	db := bunorm.NewDB()
+
+	// Clean up test data
+	defer func() {
+		_, err := db.NewDelete().
+			Model((*projectModels.BunProject)(nil)).
+			Where("name LIKE 'test_%'").
+			Exec(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Create a new project using Bun
+	project := &projectModels.BunProject{
+		Name:         "test_project",
+		OwnerID:      1,
+		Deleted:      false,
+		RegistryID:   0,
+		CreationTime: time.Now(),
+		UpdateTime:   time.Now(),
+	}
+
+	// Insert using Bun ORM
+	_, err := db.NewInsert().Model(project).Exec(ctx)
+	require.NoError(t, err)
+	assert.Greater(t, project.ProjectID, int64(0))
+
+	// Query with filters (demonstrating Bun query builder)
+	var projects []projectModels.BunProject
+	err = db.NewSelect().
+		Model(&projects).
+		Where("deleted = ?", false).
+		Where("name LIKE ?", "test_%").
+		Order("creation_time DESC").
+		Limit(10).
+		Scan(ctx)
+	require.NoError(t, err)
+	assert.Len(t, projects, 1)
+	assert.Equal(t, project.Name, projects[0].Name)
+}
+
+// testTransactionExample demonstrates transaction handling with Bun
+func testTransactionExample(t *testing.T) {
+	ctx := context.Background()
+
+	// Clean up test data
+	defer func() {
+		db := bunorm.NewDB()
+		_, err := db.NewDelete().
+			Model((*models.BunConfigEntry)(nil)).
+			Where("k LIKE 'tx_test_%'").
+			Exec(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Test successful transaction
+	err := bunorm.WithTx(ctx, func(tx bunorm.Transaction) error {
+		// Insert multiple config entries in a transaction
+		configs := []*models.BunConfigEntry{
+			{Key: "tx_test_1", Value: "value1"},
+			{Key: "tx_test_2", Value: "value2"},
+		}
+
+		for _, config := range configs {
+			_, err := tx.NewInsert().Model(config).Exec(ctx)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Verify both entries were created
+	db := bunorm.NewDB()
+	count, err := db.NewSelect().
+		Model((*models.BunConfigEntry)(nil)).
+		Where("k LIKE 'tx_test_%'").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 2, count)
+
+	// Test rollback transaction
+	err = bunorm.WithTx(ctx, func(tx bunorm.Transaction) error {
+		// Insert a config entry
+		config := &models.BunConfigEntry{
+			Key:   "tx_test_rollback",
+			Value: "should_not_exist",
+		}
+		_, err := tx.NewInsert().Model(config).Exec(ctx)
+		if err != nil {
+			return err
+		}
+
+		// Force rollback by returning an error
+		return assert.AnError
+	})
+	require.Error(t, err)
+
+	// Verify the entry was not created due to rollback
+	count, err = db.NewSelect().
+		Model((*models.BunConfigEntry)(nil)).
+		Where("k = 'tx_test_rollback'").
+		Count(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 0, count)
+}
+
+// testQueryBuilderExample demonstrates advanced query building with Bun
+func testQueryBuilderExample(t *testing.T) {
+	ctx := context.Background()
+	db := bunorm.NewDB()
+
+	// Clean up test data
+	defer func() {
+		_, err := db.NewDelete().
+			Model((*projectModels.BunProject)(nil)).
+			Where("name LIKE 'query_test_%'").
+			Exec(ctx)
+		require.NoError(t, err)
+	}()
+
+	// Create test data
+	projects := []*projectModels.BunProject{
+		{Name: "query_test_public", OwnerID: 1, Deleted: false},
+		{Name: "query_test_private", OwnerID: 2, Deleted: false},
+		{Name: "query_test_deleted", OwnerID: 1, Deleted: true},
+	}
+
+	for _, project := range projects {
+		_, err := db.NewInsert().Model(project).Exec(ctx)
+		require.NoError(t, err)
+	}
+
+	// Test complex query with subquery
+	var activeProjects []projectModels.BunProject
+	err := db.NewSelect().
+		Model(&activeProjects).
+		Where("deleted = ?", false).
+		Where("name LIKE ?", "query_test_%").
+		Where("owner_id IN (?)", db.NewSelect().
+			Column("DISTINCT owner_id").
+			Table("project").
+			Where("deleted = ?", false)).
+		Order("name ASC").
+		Scan(ctx)
+	require.NoError(t, err)
+	assert.Len(t, activeProjects, 2)
+
+	// Test aggregate query
+	type OwnerStats struct {
+		OwnerID      int   `bun:"owner_id"`
+		ProjectCount int   `bun:"project_count"`
+		ActiveCount  int   `bun:"active_count"`
+	}
+
+	var stats []OwnerStats
+	err = db.NewSelect().
+		Column("owner_id").
+		ColumnExpr("COUNT(*) as project_count").
+		ColumnExpr("COUNT(CASE WHEN deleted = false THEN 1 END) as active_count").
+		Table("project").
+		Where("name LIKE ?", "query_test_%").
+		Group("owner_id").
+		Order("owner_id ASC").
+		Scan(ctx, &stats)
+	require.NoError(t, err)
+	assert.Len(t, stats, 2)
+
+	// Owner 1 should have 2 projects (1 active, 1 deleted)
+	owner1Stats := stats[0]
+	assert.Equal(t, 1, owner1Stats.OwnerID)
+	assert.Equal(t, 2, owner1Stats.ProjectCount)
+	assert.Equal(t, 1, owner1Stats.ActiveCount)
+
+	// Owner 2 should have 1 project (1 active)
+	owner2Stats := stats[1]
+	assert.Equal(t, 2, owner2Stats.OwnerID)
+	assert.Equal(t, 1, owner2Stats.ProjectCount)
+	assert.Equal(t, 1, owner2Stats.ActiveCount)
+}
+
+// BenchmarkBunVsBeego compares performance between Bun and Beego (simulation)
+func BenchmarkBunVsBeego(b *testing.B) {
+	// Skip if no test database configured
+	if os.Getenv("TEST_DB_HOST") == "" {
+		b.Skip("No test database configured")
+	}
+
+	// Initialize Bun database
+	config := &bunorm.Config{
+		Host:         os.Getenv("TEST_DB_HOST"),
+		Port:         5432,
+		Username:     os.Getenv("TEST_DB_USER"),
+		Password:     os.Getenv("TEST_DB_PASSWORD"),
+		Database:     os.Getenv("TEST_DB_NAME"),
+		SSLMode:      "disable",
+		MaxIdleConns: 10,
+		MaxOpenConns: 20,
+		MaxLifetime:  time.Hour,
+		ConnTimeout:  time.Second * 30,
+	}
+
+	err := bunorm.InitDB(config)
+	if err != nil {
+		b.Fatalf("Failed to initialize database: %v", err)
+	}
+	defer bunorm.Close()
+
+	ctx := context.Background()
+	db := bunorm.NewDB()
+
+	// Setup benchmark data
+	_, err = db.NewInsert().
+		Model(&models.BunConfigEntry{Key: "bench_test", Value: "benchmark_value"}).
+		Exec(ctx)
+	if err != nil {
+		b.Fatalf("Failed to create benchmark data: %v", err)
+	}
+
+	defer func() {
+		_, err := db.NewDelete().
+			Model((*models.BunConfigEntry)(nil)).
+			Where("k = 'bench_test'").
+			Exec(ctx)
+		if err != nil {
+			b.Logf("Failed to clean up benchmark data: %v", err)
+		}
+	}()
+
+	b.Run("BunSelect", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			var config models.BunConfigEntry
+			err := db.NewSelect().
+				Model(&config).
+				Where("k = ?", "bench_test").
+				Scan(ctx)
+			if err != nil {
+				b.Fatalf("Bun select failed: %v", err)
+			}
+		}
+	})
+
+	// Note: This would be the Beego comparison in a real scenario
+	// b.Run("BeegoSelect", func(b *testing.B) {
+	//     for i := 0; i < b.N; i++ {
+	//         o := orm.NewOrm()
+	//         var config models.ConfigEntry
+	//         err := o.QueryTable("properties").Filter("k", "bench_test").One(&config)
+	//         if err != nil {
+	//             b.Fatalf("Beego select failed: %v", err)
+	//         }
+	//     }
+	// })
+}
+
+// Example usage documentation
+func ExampleBunMigration() {
+	// This example shows how to migrate from Beego ORM to Bun ORM
+
+	// 1. Initialize Bun database
+	config := &bunorm.Config{
+		Host:     "localhost",
+		Port:     5432,
+		Username: "harbor",
+		Password: "password",
+		Database: "harbor",
+		SSLMode:  "disable",
+	}
+	bunorm.InitDB(config)
+
+	// 2. Use Bun models instead of Beego models
+	ctx := context.Background()
+	db := bunorm.NewDB()
+
+	// Old Beego way:
+	// o := orm.NewOrm()
+	// var projects []models.Project
+	// _, err := o.QueryTable("project").Filter("deleted", false).All(&projects)
+
+	// New Bun way:
+	var projects []projectModels.BunProject
+	err := db.NewSelect().
+		Model(&projects).
+		Where("deleted = ?", false).
+		Scan(ctx)
+	_ = err
+
+	// 3. Use transactions with Bun
+	err = bunorm.WithTx(ctx, func(tx bunorm.Transaction) error {
+		project := &projectModels.BunProject{
+			Name:    "example_project",
+			OwnerID: 1,
+		}
+		_, err := tx.NewInsert().Model(project).Exec(ctx)
+		return err
+	})
+	_ = err
+
+	// Output: Migration completed successfully
+}

--- a/src/go.mod
+++ b/src/go.mod
@@ -11,6 +11,10 @@ require (
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/beego/beego/v2 v2.3.6
 	github.com/beego/i18n v0.0.0-20140604031826-e87155e8f0c0
+	github.com/uptrace/bun v1.1.16
+	github.com/uptrace/bun/driver/pgdriver v1.1.16
+	github.com/uptrace/bun/dialect/pgdialect v1.1.16
+	github.com/uptrace/bun/extra/bundebug v1.1.16
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/casbin/casbin v1.9.1
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/src/lib/bunorm/db.go
+++ b/src/lib/bunorm/db.go
@@ -1,0 +1,281 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bunorm
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/uptrace/bun"
+	"github.com/uptrace/bun/dialect/pgdialect"
+	"github.com/uptrace/bun/driver/pgdriver"
+	"github.com/uptrace/bun/extra/bundebug"
+
+	"github.com/goharbor/harbor/src/lib/errors"
+	"github.com/goharbor/harbor/src/lib/log"
+)
+
+var (
+	// GlobalDB is the global database instance for Bun ORM
+	GlobalDB *bun.DB
+)
+
+// Config holds the database configuration
+type Config struct {
+	Host         string
+	Port         int
+	Username     string
+	Password     string
+	Database     string
+	SSLMode      string
+	MaxIdleConns int
+	MaxOpenConns int
+	MaxLifetime  time.Duration
+	ConnTimeout  time.Duration
+}
+
+// InitDB initializes the Bun database connection
+func InitDB(config *Config) error {
+	// Build PostgreSQL connection string
+	dsn := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s",
+		config.Username,
+		config.Password,
+		config.Host,
+		config.Port,
+		config.Database,
+		config.SSLMode,
+	)
+
+	// Create SQL database connection
+	sqldb := sql.OpenDB(pgdriver.NewConnector(pgdriver.WithDSN(dsn)))
+
+	// Configure connection pool
+	sqldb.SetMaxIdleConns(config.MaxIdleConns)
+	sqldb.SetMaxOpenConns(config.MaxOpenConns)
+	sqldb.SetConnMaxLifetime(config.MaxLifetime)
+
+	// Create Bun database instance
+	GlobalDB = bun.NewDB(sqldb, pgdialect.New())
+
+	// Add debugging if needed
+	if os.Getenv("BUN_DEBUG") == "true" {
+		GlobalDB.AddQueryHook(bundebug.NewQueryHook(
+			bundebug.WithVerbose(true),
+			bundebug.FromEnv("BUN_DEBUG"),
+		))
+	}
+
+	// Test the connection
+	ctx, cancel := context.WithTimeout(context.Background(), config.ConnTimeout)
+	defer cancel()
+
+	if err := GlobalDB.PingContext(ctx); err != nil {
+		return fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	log.Info("Bun database connection initialized successfully")
+	return nil
+}
+
+// GetDB returns the global database instance
+func GetDB() *bun.DB {
+	if GlobalDB == nil {
+		log.Fatal("Database not initialized. Call InitDB first.")
+	}
+	return GlobalDB
+}
+
+// Close closes the database connection
+func Close() error {
+	if GlobalDB != nil {
+		return GlobalDB.Close()
+	}
+	return nil
+}
+
+// WithTx runs a function within a database transaction
+func WithTx(ctx context.Context, fn func(tx bun.Tx) error) error {
+	return GlobalDB.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		return fn(tx)
+	})
+}
+
+// Transaction interface for compatibility
+type Transaction interface {
+	NewSelect() *bun.SelectQuery
+	NewInsert() *bun.InsertQuery
+	NewUpdate() *bun.UpdateQuery
+	NewDelete() *bun.DeleteQuery
+	NewRaw(query string, args ...interface{}) *bun.RawQuery
+}
+
+// DB wrapper that provides both transaction and non-transaction operations
+type DB struct {
+	*bun.DB
+}
+
+// NewDB creates a new DB wrapper
+func NewDB() *DB {
+	return &DB{DB: GetDB()}
+}
+
+// TxDB wraps a Bun transaction to provide the same interface as DB
+type TxDB struct {
+	tx bun.Tx
+}
+
+// NewSelect implements Transaction interface
+func (db *DB) NewSelect() *bun.SelectQuery {
+	return db.DB.NewSelect()
+}
+
+// NewInsert implements Transaction interface
+func (db *DB) NewInsert() *bun.InsertQuery {
+	return db.DB.NewInsert()
+}
+
+// NewUpdate implements Transaction interface
+func (db *DB) NewUpdate() *bun.UpdateQuery {
+	return db.DB.NewUpdate()
+}
+
+// NewDelete implements Transaction interface
+func (db *DB) NewDelete() *bun.DeleteQuery {
+	return db.DB.NewDelete()
+}
+
+// NewRaw implements Transaction interface
+func (db *DB) NewRaw(query string, args ...interface{}) *bun.RawQuery {
+	return db.DB.NewRaw(query, args...)
+}
+
+// BeginTx starts a transaction and returns TxDB
+func (db *DB) BeginTx(ctx context.Context) (*TxDB, error) {
+	tx, err := db.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &TxDB{tx: tx}, nil
+}
+
+// NewSelect implements Transaction interface for TxDB
+func (tx *TxDB) NewSelect() *bun.SelectQuery {
+	return tx.tx.NewSelect()
+}
+
+// NewInsert implements Transaction interface for TxDB
+func (tx *TxDB) NewInsert() *bun.InsertQuery {
+	return tx.tx.NewInsert()
+}
+
+// NewUpdate implements Transaction interface for TxDB
+func (tx *TxDB) NewUpdate() *bun.UpdateQuery {
+	return tx.tx.NewUpdate()
+}
+
+// NewDelete implements Transaction interface for TxDB
+func (tx *TxDB) NewDelete() *bun.DeleteQuery {
+	return tx.tx.NewDelete()
+}
+
+// NewRaw implements Transaction interface for TxDB
+func (tx *TxDB) NewRaw(query string, args ...interface{}) *bun.RawQuery {
+	return tx.tx.NewRaw(query, args...)
+}
+
+// Commit commits the transaction
+func (tx *TxDB) Commit() error {
+	return tx.tx.Commit()
+}
+
+// Rollback rolls back the transaction
+func (tx *TxDB) Rollback() error {
+	return tx.tx.Rollback()
+}
+
+// CompatDB provides a compatibility layer between Beego ORM and Bun
+type CompatDB struct {
+	db Transaction
+}
+
+// NewCompatDB creates a new compatibility database wrapper
+func NewCompatDB(tx Transaction) *CompatDB {
+	return &CompatDB{db: tx}
+}
+
+// Insert inserts a record using Bun syntax compatible with Beego patterns
+func (c *CompatDB) Insert(ctx context.Context, model interface{}) (int64, error) {
+	result, err := c.db.NewInsert().Model(model).Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// Update updates a record using Bun syntax
+func (c *CompatDB) Update(ctx context.Context, model interface{}) (int64, error) {
+	result, err := c.db.NewUpdate().Model(model).WherePK().Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// Delete deletes a record using Bun syntax
+func (c *CompatDB) Delete(ctx context.Context, model interface{}) (int64, error) {
+	result, err := c.db.NewDelete().Model(model).WherePK().Exec(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+// SelectOne selects a single record
+func (c *CompatDB) SelectOne(ctx context.Context, model interface{}) error {
+	return c.db.NewSelect().Model(model).WherePK().Scan(ctx)
+}
+
+// SelectMany selects multiple records
+func (c *CompatDB) SelectMany(ctx context.Context, models interface{}) error {
+	return c.db.NewSelect().Model(models).Scan(ctx)
+}
+
+// contextKey for storing Bun DB in context
+type contextKey struct{}
+
+// FromContext returns Bun DB from context
+func FromContext(ctx context.Context) (Transaction, error) {
+	db, ok := ctx.Value(contextKey{}).(Transaction)
+	if !ok {
+		return nil, errors.New("cannot get the Bun DB from context")
+	}
+	return db, nil
+}
+
+// NewContext returns new context with Bun DB
+func NewContext(ctx context.Context, db Transaction) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, contextKey{}, db)
+}
+
+// Context returns a context with Bun DB
+func Context() context.Context {
+	return NewContext(context.Background(), NewDB())
+}

--- a/src/lib/config/models/bun_model.go
+++ b/src/lib/config/models/bun_model.go
@@ -1,0 +1,99 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"time"
+	"github.com/uptrace/bun"
+)
+
+// BunConfigEntry is the Bun ORM version of ConfigEntry
+// Migrated from Beego ORM to Bun ORM
+type BunConfigEntry struct {
+	bun.BaseModel `bun:"table:properties"`
+
+	// Beego: orm:"pk;auto;column(id)" -> Bun: bun:",pk,autoincrement"
+	ID int64 `bun:",pk,autoincrement" json:"-"`
+	
+	// Beego: orm:"column(k)" -> Bun: bun:"k"
+	Key string `bun:"k" json:"k"`
+	
+	// Beego: orm:"column(v)" -> Bun: bun:"v"
+	Value string `bun:"v" json:"v"`
+}
+
+// Migration mapping documentation:
+//
+// Beego ORM Tag                    | Bun ORM Tag                    | Description
+// --------------------------------|--------------------------------|------------------
+// orm:"pk;auto;column(id)"        | bun:",pk,autoincrement"        | Primary key auto increment
+// orm:"column(name)"              | bun:"name"                     | Column name mapping
+// orm:"auto_now_add"              | bun:",nullzero,notnull,default:current_timestamp" | Created timestamp
+// orm:"auto_now"                  | bun:",nullzero,notnull,default:current_timestamp" | Updated timestamp  
+// orm:"-"                         | bun:"-"                        | Ignore field
+// orm:"size(255)"                 | bun:",type:varchar(255)"       | Field type specification
+// orm:"null"                      | bun:",nullzero"                | Allow null values
+// orm:"unique"                    | bun:",unique"                  | Unique constraint
+// TableName() method              | bun:"table:table_name"         | Table name in BaseModel tag
+
+// Example of a more complex model migration:
+type BunExampleModel struct {
+	bun.BaseModel `bun:"table:example_table"`
+
+	// Primary key with auto increment
+	ID int64 `bun:",pk,autoincrement" json:"id"`
+	
+	// Regular string field with column name
+	Name string `bun:"name,notnull" json:"name"`
+	
+	// Email with unique constraint
+	Email string `bun:"email,unique,notnull" json:"email"`
+	
+	// Optional field that can be null
+	Description string `bun:"description,nullzero" json:"description,omitempty"`
+	
+	// Timestamp fields
+	CreatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"created_at"`
+	UpdatedAt time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"updated_at"`
+	
+	// Fields ignored by ORM (computed or temporary)
+	TempData string `bun:"-" json:"-"`
+}
+
+// Key differences between Beego and Bun:
+//
+// 1. Table Name:
+//    - Beego: TableName() method
+//    - Bun: bun:"table:table_name" tag on bun.BaseModel
+//
+// 2. Primary Key:
+//    - Beego: orm:"pk;auto"
+//    - Bun: bun:",pk,autoincrement"
+//
+// 3. Column Names:
+//    - Beego: orm:"column(name)"
+//    - Bun: bun:"name"
+//
+// 4. Timestamps:
+//    - Beego: orm:"auto_now_add" or orm:"auto_now"
+//    - Bun: bun:",nullzero,notnull,default:current_timestamp"
+//
+// 5. Null Values:
+//    - Beego: orm:"null"
+//    - Bun: bun:",nullzero"
+//
+// 6. Ignore Fields:
+//    - Beego: orm:"-"
+//    - Bun: bun:"-"

--- a/src/pkg/project/models/bun_project.go
+++ b/src/pkg/project/models/bun_project.go
@@ -1,0 +1,318 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package models
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/uptrace/bun"
+
+	"github.com/goharbor/harbor/src/lib/bunorm"
+	allowlist "github.com/goharbor/harbor/src/pkg/allowlist/models"
+)
+
+const (
+	// BunProjectTable is the table name for project in Bun
+	BunProjectTable = "project"
+)
+
+// BunProject holds the details of a project using Bun ORM.
+// Migrated from Beego ORM to Bun ORM
+type BunProject struct {
+	bun.BaseModel `bun:"table:project"`
+
+	// Beego: orm:"pk;auto;column(project_id)" -> Bun: bun:",pk,autoincrement"
+	ProjectID int64 `bun:",pk,autoincrement" json:"project_id"`
+	
+	// Beego: orm:"column(owner_id)" -> Bun: bun:"owner_id"
+	OwnerID int `bun:"owner_id" json:"owner_id"`
+	
+	// Beego: orm:"column(name)" -> Bun: bun:"name"
+	Name string `bun:"name" json:"name" sort:"default"`
+	
+	// Beego: orm:"column(creation_time);auto_now_add" -> Bun: bun:",nullzero,notnull,default:current_timestamp"
+	CreationTime time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"creation_time"`
+	
+	// Beego: orm:"column(update_time);auto_now" -> Bun: bun:",nullzero,notnull,default:current_timestamp"
+	UpdateTime time.Time `bun:",nullzero,notnull,default:current_timestamp" json:"update_time"`
+	
+	// Beego: orm:"column(deleted)" -> Bun: bun:"deleted"
+	Deleted bool `bun:"deleted" json:"deleted"`
+	
+	// Beego: orm:"-" -> Bun: bun:"-"
+	OwnerName    string                     `bun:"-" json:"owner_name"`
+	Role         int                        `bun:"-" json:"current_user_role_id"`
+	RoleList     []int                      `bun:"-" json:"current_user_role_ids"`
+	RepoCount    int64                      `bun:"-" json:"repo_count"`
+	Metadata     map[string]string          `bun:"-" json:"metadata"`
+	CVEAllowlist allowlist.CVEAllowlist     `bun:"-" json:"cve_allowlist"`
+	
+	// Beego: orm:"column(registry_id)" -> Bun: bun:"registry_id"
+	RegistryID int64 `bun:"registry_id" json:"registry_id"`
+}
+
+// BunNamesQuery is the Bun version of NamesQuery
+type BunNamesQuery struct {
+	Names      []string // the names of project
+	WithPublic bool     // include the public projects
+}
+
+// GetMetadata ...
+func (p *BunProject) GetMetadata(key string) (string, bool) {
+	if len(p.Metadata) == 0 {
+		return "", false
+	}
+	value, exist := p.Metadata[key]
+	return value, exist
+}
+
+// SetMetadata ...
+func (p *BunProject) SetMetadata(key, value string) {
+	if p.Metadata == nil {
+		p.Metadata = map[string]string{}
+	}
+	p.Metadata[key] = value
+}
+
+// IsPublic ...
+func (p *BunProject) IsPublic() bool {
+	public, exist := p.GetMetadata(ProMetaPublic)
+	if !exist {
+		return false
+	}
+
+	return isTrue(public)
+}
+
+// IsProxy returns true when the project type is proxy cache
+func (p *BunProject) IsProxy() bool {
+	return p.RegistryID > 0
+}
+
+// ContentTrustEnabled ...
+func (p *BunProject) ContentTrustEnabled() bool {
+	enabled, exist := p.GetMetadata(ProMetaEnableContentTrust)
+	if !exist {
+		return false
+	}
+	return isTrue(enabled)
+}
+
+// ContentTrustCosignEnabled ...
+func (p *BunProject) ContentTrustCosignEnabled() bool {
+	enabled, exist := p.GetMetadata(ProMetaEnableContentTrustCosign)
+	if !exist {
+		return false
+	}
+	return isTrue(enabled)
+}
+
+// VulPrevented ...
+func (p *BunProject) VulPrevented() bool {
+	prevent, exist := p.GetMetadata(ProMetaPreventVul)
+	if !exist {
+		return false
+	}
+	return isTrue(prevent)
+}
+
+// ReuseSysCVEAllowlist ...
+func (p *BunProject) ReuseSysCVEAllowlist() bool {
+	r, ok := p.GetMetadata(ProMetaReuseSysCVEAllowlist)
+	if !ok {
+		return true
+	}
+	return isTrue(r)
+}
+
+// Severity ...
+func (p *BunProject) Severity() string {
+	severity, exist := p.GetMetadata(ProMetaSeverity)
+	if !exist {
+		return ""
+	}
+	return severity
+}
+
+// AutoScan ...
+func (p *BunProject) AutoScan() bool {
+	auto, exist := p.GetMetadata(ProMetaAutoScan)
+	if !exist {
+		return false
+	}
+	return isTrue(auto)
+}
+
+// AutoSBOMGen ...
+func (p *BunProject) AutoSBOMGen() bool {
+	auto, exist := p.GetMetadata(ProMetaAutoSBOMGen)
+	if !exist {
+		return false
+	}
+	return isTrue(auto)
+}
+
+// ProxyCacheSpeed ...
+func (p *BunProject) ProxyCacheSpeed() int32 {
+	speed, exist := p.GetMetadata(ProMetaProxySpeed)
+	if !exist {
+		return 0
+	}
+	speedInt, err := strconv.ParseInt(speed, 10, 32)
+	if err != nil {
+		return 0
+	}
+	return int32(speedInt)
+}
+
+// BunProjectDAO provides database operations for BunProject using Bun ORM
+type BunProjectDAO struct{}
+
+// FilterByPublic applies public filter to Bun query
+func (dao *BunProjectDAO) FilterByPublic(ctx context.Context, query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
+	subQuery := `SELECT project_id FROM project_metadata WHERE name = 'public' AND value = '%s'`
+	if isTrue(value) {
+		subQuery = fmt.Sprintf(subQuery, "true")
+	} else {
+		subQuery = fmt.Sprintf(subQuery, "false")
+	}
+	return query.Where(fmt.Sprintf("project_id IN (%s)", subQuery))
+}
+
+// FilterByOwner applies owner filter to Bun query
+func (dao *BunProjectDAO) FilterByOwner(ctx context.Context, query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
+	username, ok := value.(string)
+	if !ok {
+		return query
+	}
+
+	return query.Where("owner_id IN (SELECT user_id FROM harbor_user WHERE username = ?)", username)
+}
+
+// FilterByMember applies member filter to Bun query
+func (dao *BunProjectDAO) FilterByMember(ctx context.Context, query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
+	memberQuery, ok := value.(*BunMemberQuery)
+	if !ok {
+		return query
+	}
+
+	subQuery := fmt.Sprintf(`SELECT project_id FROM project_member WHERE entity_id = %d AND entity_type = 'u'`, memberQuery.UserID)
+	if memberQuery.Role > 0 {
+		subQuery = fmt.Sprintf("%s AND role = %d", subQuery, memberQuery.Role)
+	}
+
+	if memberQuery.WithPublic {
+		subQuery = fmt.Sprintf("(%s) UNION (SELECT project_id FROM project_metadata WHERE name = 'public' AND value = 'true')", subQuery)
+	}
+
+	if len(memberQuery.GroupIDs) > 0 {
+		var elems []string
+		for _, groupID := range memberQuery.GroupIDs {
+			elems = append(elems, strconv.Itoa(groupID))
+		}
+
+		tpl := "(%s) UNION (SELECT project_id FROM project_member pm, user_group ug WHERE pm.entity_id = ug.id AND pm.entity_type = 'g' AND ug.id IN (%s))"
+		subQuery = fmt.Sprintf(tpl, subQuery, strings.TrimSpace(strings.Join(elems, ", ")))
+	}
+
+	return query.Where(fmt.Sprintf("project_id IN (%s)", subQuery))
+}
+
+// FilterByNames applies names filter to Bun query
+func (dao *BunProjectDAO) FilterByNames(ctx context.Context, query *bun.SelectQuery, value interface{}) *bun.SelectQuery {
+	namesQuery, ok := value.(*BunNamesQuery)
+	if !ok {
+		return query
+	}
+
+	if len(namesQuery.Names) == 0 {
+		return query
+	}
+
+	// Use Bun's In() method for safer query building
+	subQuery := query.NewSelect().
+		Column("project_id").
+		Table("project").
+		Where("name IN (?)", bun.In(namesQuery.Names))
+
+	if namesQuery.WithPublic {
+		publicQuery := query.NewSelect().
+			Column("project_id").
+			Table("project_metadata").
+			Where("name = 'public' AND value = 'true'")
+		
+		// Union the queries
+		return query.Where("project_id IN (?) OR project_id IN (?)", subQuery, publicQuery)
+	}
+
+	return query.Where("project_id IN (?)", subQuery)
+}
+
+// BunMemberQuery is the Bun version of MemberQuery
+type BunMemberQuery struct {
+	UserID     int
+	Role       int
+	WithPublic bool
+	GroupIDs   []int
+}
+
+// BunProjects is a slice of BunProject pointers
+type BunProjects []*BunProject
+
+// OwnerIDs returns all the owner ids from the projects
+func (projects BunProjects) OwnerIDs() []int {
+	var ownerIDs []int
+	for _, project := range projects {
+		ownerIDs = append(ownerIDs, project.OwnerID)
+	}
+	return ownerIDs
+}
+
+// Example usage of BunProject with database operations:
+//
+// // Get database from context
+// db, err := bunorm.FromContext(ctx)
+// if err != nil {
+//     return err
+// }
+//
+// // Select all projects
+// var projects []BunProject
+// err = db.NewSelect().Model(&projects).Scan(ctx)
+//
+// // Select project by ID
+// var project BunProject
+// err = db.NewSelect().Model(&project).Where("project_id = ?", id).Scan(ctx)
+//
+// // Insert new project
+// project := &BunProject{Name: "test", OwnerID: 1}
+// _, err = db.NewInsert().Model(project).Exec(ctx)
+//
+// // Update project
+// _, err = db.NewUpdate().Model(&project).WherePK().Exec(ctx)
+//
+// // Delete project
+// _, err = db.NewDelete().Model(&project).WherePK().Exec(ctx)
+//
+// // Complex query with filters
+// dao := &BunProjectDAO{}
+// query := db.NewSelect().Model(&projects)
+// query = dao.FilterByPublic(ctx, query, true)
+// query = dao.FilterByOwner(ctx, query, "admin")
+// err = query.Scan(ctx)

--- a/src/server/middleware/bunorm/middleware.go
+++ b/src/server/middleware/bunorm/middleware.go
@@ -1,0 +1,128 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bunorm
+
+import (
+	"net/http"
+
+	"github.com/goharbor/harbor/src/lib/bunorm"
+	"github.com/goharbor/harbor/src/server/middleware"
+)
+
+// Config defines the config for Bun ORM middleware.
+type Config struct {
+	// Creator defines a function to create Bun transaction
+	Creator func() bunorm.Transaction
+}
+
+var (
+	// DefaultConfig default Bun ORM config
+	DefaultConfig = Config{
+		Creator: func() bunorm.Transaction {
+			return bunorm.NewDB()
+		},
+	}
+)
+
+// Middleware middleware which adds Bun DB to the http request context with default config
+func Middleware(skippers ...middleware.Skipper) func(http.Handler) http.Handler {
+	return MiddlewareWithConfig(DefaultConfig, skippers...)
+}
+
+// MiddlewareWithConfig middleware which adds Bun DB to the http request context with config
+func MiddlewareWithConfig(config Config, skippers ...middleware.Skipper) func(http.Handler) http.Handler {
+	if config.Creator == nil {
+		config.Creator = DefaultConfig.Creator
+	}
+
+	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		ctx := bunorm.NewContext(r.Context(), config.Creator())
+		next.ServeHTTP(w, r.WithContext(ctx))
+	}, skippers...)
+}
+
+// TransactionMiddleware provides transaction-aware middleware
+// This creates a transaction for each request and commits/rollbacks automatically
+func TransactionMiddleware(skippers ...middleware.Skipper) func(http.Handler) http.Handler {
+	return middleware.New(func(w http.ResponseWriter, r *http.Request, next http.Handler) {
+		db := bunorm.NewDB()
+		
+		tx, err := db.BeginTx(r.Context())
+		if err != nil {
+			http.Error(w, "Failed to start transaction", http.StatusInternalServerError)
+			return
+		}
+
+		ctx := bunorm.NewContext(r.Context(), tx)
+		
+		// Custom response writer to track if we should commit or rollback
+		rw := &responseWriter{
+			ResponseWriter: w,
+			tx:            tx,
+			committed:     false,
+		}
+
+		defer func() {
+			if !rw.committed {
+				// If we haven't committed yet and there's an error, rollback
+				if rw.statusCode >= 400 {
+					tx.Rollback()
+				} else {
+					tx.Commit()
+				}
+			}
+		}()
+
+		next.ServeHTTP(rw, r.WithContext(ctx))
+	}, skippers...)
+}
+
+// responseWriter wraps http.ResponseWriter to track response status
+type responseWriter struct {
+	http.ResponseWriter
+	tx         *bunorm.TxDB
+	statusCode int
+	committed  bool
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+func (rw *responseWriter) Write(b []byte) (int, error) {
+	if rw.statusCode == 0 {
+		rw.statusCode = 200
+	}
+	return rw.ResponseWriter.Write(b)
+}
+
+// CommitTransaction commits the transaction manually
+func (rw *responseWriter) CommitTransaction() error {
+	if !rw.committed {
+		rw.committed = true
+		return rw.tx.Commit()
+	}
+	return nil
+}
+
+// RollbackTransaction rolls back the transaction manually
+func (rw *responseWriter) RollbackTransaction() error {
+	if !rw.committed {
+		rw.committed = true
+		return rw.tx.Rollback()
+	}
+	return nil
+}

--- a/tools/migration/beego_to_bun.go
+++ b/tools/migration/beego_to_bun.go
@@ -1,0 +1,324 @@
+// Copyright Project Harbor Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// TagConversion represents a mapping from Beego tag to Bun tag
+type TagConversion struct {
+	BeegoPattern string
+	BunTag       string
+	Description  string
+}
+
+// Tag conversion mappings
+var tagConversions = []TagConversion{
+	{`pk;auto;column\(([^)]+)\)`, `",pk,autoincrement"`, "Primary key with auto increment"},
+	{`pk;auto`, `",pk,autoincrement"`, "Primary key with auto increment (no column name)"},
+	{`pk;column\(([^)]+)\)`, `",pk"`, "Primary key"},
+	{`pk`, `",pk"`, "Primary key (no column name)"},
+	{`column\(([^)]+)\);auto_now_add`, `",nullzero,notnull,default:current_timestamp"`, "Creation timestamp"},
+	{`column\(([^)]+)\);auto_now`, `",nullzero,notnull,default:current_timestamp"`, "Update timestamp"},
+	{`auto_now_add`, `",nullzero,notnull,default:current_timestamp"`, "Creation timestamp (no column name)"},
+	{`auto_now`, `",nullzero,notnull,default:current_timestamp"`, "Update timestamp (no column name)"},
+	{`column\(([^)]+)\);size\(([^)]+)\)`, `"$1,type:varchar($2)"`, "Column with size"},
+	{`column\(([^)]+)\);unique`, `"$1,unique,notnull"`, "Unique column"},
+	{`column\(([^)]+)\);null`, `"$1,nullzero"`, "Nullable column"},
+	{`column\(([^)]+)\)`, `"$1"`, "Regular column"},
+	{`size\(([^)]+)\)`, `",type:varchar($1)"`, "Size specification"},
+	{`unique`, `",unique"`, "Unique constraint"},
+	{`null`, `",nullzero"`, "Nullable field"},
+	{`-`, `"-"`, "Ignored field"},
+}
+
+// ModelInfo holds information about a parsed model
+type ModelInfo struct {
+	Name      string
+	TableName string
+	Fields    []FieldInfo
+	Methods   []string
+}
+
+// FieldInfo holds information about a model field
+type FieldInfo struct {
+	Name       string
+	Type       string
+	BeegoTag   string
+	BunTag     string
+	JSONTag    string
+	OtherTags  map[string]string
+	Comment    string
+}
+
+// parseFile parses a Go file and extracts model information
+func parseFile(filename string) ([]ModelInfo, error) {
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	var models []ModelInfo
+
+	ast.Inspect(node, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.TypeSpec:
+			if structType, ok := x.Type.(*ast.StructType); ok {
+				model := parseStruct(x.Name.Name, structType)
+				if model != nil {
+					models = append(models, *model)
+				}
+			}
+		}
+		return true
+	})
+
+	return models, nil
+}
+
+// parseStruct parses a struct and extracts field information
+func parseStruct(name string, structType *ast.StructType) *ModelInfo {
+	model := &ModelInfo{
+		Name:   name,
+		Fields: make([]FieldInfo, 0),
+	}
+
+	hasORMTag := false
+
+	for _, field := range structType.Fields.List {
+		if field.Tag != nil {
+			tagValue := field.Tag.Value
+			if strings.Contains(tagValue, `orm:"`) {
+				hasORMTag = true
+			}
+
+			for _, fieldName := range field.Names {
+				fieldInfo := parseField(fieldName.Name, field)
+				model.Fields = append(model.Fields, fieldInfo)
+			}
+		}
+	}
+
+	// Only return models that have ORM tags
+	if !hasORMTag {
+		return nil
+	}
+
+	return model
+}
+
+// parseField parses a single field and converts tags
+func parseField(name string, field *ast.Field) FieldInfo {
+	fieldInfo := FieldInfo{
+		Name:      name,
+		Type:      typeToString(field.Type),
+		OtherTags: make(map[string]string),
+	}
+
+	if field.Tag != nil {
+		tags := parseStructTag(field.Tag.Value)
+		
+		if ormTag, exists := tags["orm"]; exists {
+			fieldInfo.BeegoTag = ormTag
+			fieldInfo.BunTag = convertBeegoTagToBun(ormTag)
+		}
+
+		if jsonTag, exists := tags["json"]; exists {
+			fieldInfo.JSONTag = jsonTag
+		}
+
+		for key, value := range tags {
+			if key != "orm" && key != "json" {
+				fieldInfo.OtherTags[key] = value
+			}
+		}
+	}
+
+	return fieldInfo
+}
+
+// convertBeegoTagToBun converts a Beego ORM tag to Bun ORM tag
+func convertBeegoTagToBun(beegoTag string) string {
+	for _, conversion := range tagConversions {
+		re := regexp.MustCompile(conversion.BeegoPattern)
+		if re.MatchString(beegoTag) {
+			return re.ReplaceAllString(beegoTag, conversion.BunTag)
+		}
+	}
+	
+	// If no specific conversion found, return as-is with quotes
+	if beegoTag == "-" {
+		return `"-"`
+	}
+	
+	return fmt.Sprintf(`"%s"`, beegoTag)
+}
+
+// parseStructTag parses struct tag string into map
+func parseStructTag(tag string) map[string]string {
+	tags := make(map[string]string)
+	
+	// Remove surrounding backticks
+	tag = strings.Trim(tag, "`")
+	
+	// Regular expression to match tag patterns
+	re := regexp.MustCompile(`(\w+):"([^"]*)"`)
+	matches := re.FindAllStringSubmatch(tag, -1)
+	
+	for _, match := range matches {
+		if len(match) == 3 {
+			tags[match[1]] = match[2]
+		}
+	}
+	
+	return tags
+}
+
+// typeToString converts ast.Expr to string representation
+func typeToString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return typeToString(t.X) + "." + t.Sel.Name
+	case *ast.ArrayType:
+		return "[]" + typeToString(t.Elt)
+	case *ast.MapType:
+		return "map[" + typeToString(t.Key) + "]" + typeToString(t.Value)
+	case *ast.StarExpr:
+		return "*" + typeToString(t.X)
+	default:
+		return "interface{}"
+	}
+}
+
+// generateBunModel generates Bun model code
+func generateBunModel(model ModelInfo) string {
+	var builder strings.Builder
+	
+	builder.WriteString(fmt.Sprintf("// Bun%s is the Bun ORM version of %s\n", model.Name, model.Name))
+	builder.WriteString("// Migrated from Beego ORM to Bun ORM\n")
+	builder.WriteString(fmt.Sprintf("type Bun%s struct {\n", model.Name))
+	
+	// Add BaseModel if we have a table
+	if model.TableName != "" {
+		builder.WriteString(fmt.Sprintf("\tbun.BaseModel `bun:\"table:%s\"`\n\n", model.TableName))
+	} else {
+		builder.WriteString("\tbun.BaseModel\n\n")
+	}
+	
+	for _, field := range model.Fields {
+		if field.BeegoTag != "" {
+			builder.WriteString(fmt.Sprintf("\t// Beego: orm:\"%s\" -> Bun: bun:%s\n", field.BeegoTag, field.BunTag))
+		}
+		
+		// Build the field line
+		fieldLine := fmt.Sprintf("\t%s %s", field.Name, field.Type)
+		
+		// Add tags
+		var tags []string
+		if field.BunTag != "" {
+			tags = append(tags, fmt.Sprintf("bun:%s", field.BunTag))
+		}
+		if field.JSONTag != "" {
+			tags = append(tags, fmt.Sprintf("json:\"%s\"", field.JSONTag))
+		}
+		for key, value := range field.OtherTags {
+			tags = append(tags, fmt.Sprintf("%s:\"%s\"", key, value))
+		}
+		
+		if len(tags) > 0 {
+			fieldLine += " `" + strings.Join(tags, " ") + "`"
+		}
+		
+		builder.WriteString(fieldLine + "\n")
+	}
+	
+	builder.WriteString("}\n")
+	
+	return builder.String()
+}
+
+// main function
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatal("Usage: go run beego_to_bun.go <input_file>")
+	}
+
+	filename := os.Args[1]
+	
+	models, err := parseFile(filename)
+	if err != nil {
+		log.Fatalf("Error parsing file: %v", err)
+	}
+
+	if len(models) == 0 {
+		fmt.Println("No models with ORM tags found in the file.")
+		return
+	}
+
+	// Generate output filename
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename)
+	ext := filepath.Ext(base)
+	name := strings.TrimSuffix(base, ext)
+	outputFile := filepath.Join(dir, fmt.Sprintf("bun_%s%s", name, ext))
+
+	// Generate file content
+	var output strings.Builder
+	output.WriteString("// Auto-generated Bun ORM models from Beego ORM\n")
+	output.WriteString("// Generated by beego_to_bun migration tool\n\n")
+	output.WriteString("package models\n\n")
+	output.WriteString("import (\n")
+	output.WriteString("\t\"time\"\n")
+	output.WriteString("\t\"github.com/uptrace/bun\"\n")
+	output.WriteString(")\n\n")
+
+	for _, model := range models {
+		output.WriteString(generateBunModel(model))
+		output.WriteString("\n")
+	}
+
+	// Write to output file
+	err = os.WriteFile(outputFile, []byte(output.String()), 0644)
+	if err != nil {
+		log.Fatalf("Error writing output file: %v", err)
+	}
+
+	fmt.Printf("Successfully converted %d models from %s to %s\n", len(models), filename, outputFile)
+	
+	// Print summary
+	fmt.Println("\nConverted models:")
+	for _, model := range models {
+		fmt.Printf("- %s -> Bun%s (%d fields)\n", model.Name, model.Name, len(model.Fields))
+	}
+	
+	fmt.Println("\nNext steps:")
+	fmt.Println("1. Review the generated file and adjust as needed")
+	fmt.Println("2. Add necessary imports")
+	fmt.Println("3. Update table names if needed")
+	fmt.Println("4. Test the generated models")
+	fmt.Println("5. Update DAO layer to use Bun queries")
+}


### PR DESCRIPTION
```
Thank you for contributing to Harbor!

%23 Comprehensive Summary of your change
This PR initiates the strategic migration of Harbor's ORM layer from Beego ORM to Bun ORM. It establishes the foundational Bun infrastructure, including database connection management, transaction handling, and a new middleware. Example model migrations (`ConfigEntry`, `Project`) demonstrate the conversion process, supported by an automated tag migration tool. Comprehensive guides and test examples are provided. This migration aims to significantly improve database performance, enhance developer experience through type-safe queries, and modernize Harbor's data access layer.

%23 Issue being fixed
Enhancement: ORM Migration from Beego to Bun

Please indicate you've done the following:
- [ ] Well Written Title and Summary of the PR
- [ ] Label the PR as needed. "release-note/ignore-for-release, release-note/new-feature, release-note/update, release-note/enhancement, release-note/community, release-note/breaking-change, release-note/docs, release-note/infra, release-note/deprecation"
- [ ] Accepted the DCO. Commits without the DCO will delay acceptance.
- [ ] Made sure tests are passing and test coverage is added if needed.
- [ ] Considered the docs impact and opened a new docs issue or PR with docs changes if needed in [website repository](https://github.com/goharbor/website).
```